### PR TITLE
Use buffered reading when possible to improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Makefile.rules
 .vscode/
 .cache/
 json-parser
+tests/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ clean:
 	if [ -f "json-parser" ]; then rm json-parser; fi
 
 valgrind-compile: clean
-	$(CC) $(CFLAGS) -DVALGRING_DISABLE_PRINT $(CFILES) -o json-parser
+	$(CC) $(CFLAGS) \
+		-DVALGRING_DISABLE_PRINT \
+		$(CFILES) -o json-parser
 
 valgrind: valgrind-compile
 	valgrind --tool=callgrind --dump-instr=yes \

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ json-parser:
 clean:
 	if [ -f "json-parser" ]; then rm json-parser; fi
 
+.PHONY:
+test:
+	$(CC) $(CFLAGS) tests/tests.cpp -o tests/run-tests
+	./tests/run-tests
+
 valgrind-compile: clean
 	$(CC) $(CFLAGS) \
 		-DVALGRING_DISABLE_PRINT \

--- a/r.json
+++ b/r.json
@@ -1,22 +1,68 @@
-{
-  "test": "stringi[nining",
-  "num": 51065.689888564,
-  "boool": true,
-  "empty": {
-    "t": {
+[
+  {
+    "test": "stringi[nining",
+    "num": 51065.689888564,
+    "boool": true,
+    "empty": {
       "t": {
         "t": {
-          "t": {}
+          "t": {
+            "t": {}
+          }
         }
       }
-    }
+    },
+    "dict": {
+      "empty": [[1, [[2], [[]], 3]]],
+      "num": 563,
+      "u": 2e10
+    },
+    "boo": false,
+    "n": null,
+    "arr": ["testing", 546884, null, false, [1], [1, 2, 3, 5], true]
   },
-  "dict": {
-    "empty": [[1, [[2], [[]], 3]]],
-    "num": 563,
-    "u": 2e10
+  {
+    "test": "stringi[nining",
+    "num": 51065.689888564,
+    "boool": true,
+    "empty": {
+      "t": {
+        "t": {
+          "t": {
+            "t": {}
+          }
+        }
+      }
+    },
+    "dict": {
+      "empty": [[1, [[2], [[]], 3]]],
+      "num": 563,
+      "u": 2e10
+    },
+    "boo": false,
+    "n": null,
+    "arr": ["testing", 546884, null, false, [1], [1, 2, 3, 5], true]
   },
-  "boo": false,
-  "n": null,
-  "arr": ["testing", 546884, null, false, [1], [1, 2, 3, 5], true]
-}
+  {
+    "test": "stringi[nining",
+    "num": 51065.689888564,
+    "boool": true,
+    "empty": {
+      "t": {
+        "t": {
+          "t": {
+            "t": {}
+          }
+        }
+      }
+    },
+    "dict": {
+      "empty": [[1, [[2], [[]], 3]]],
+      "num": 563,
+      "u": 2e10
+    },
+    "boo": false,
+    "n": null,
+    "arr": ["testing", 546884, null, false, [1], [1, 2, 3, 5], true]
+  }
+]

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -486,6 +486,11 @@ void JSONDict::addItem(Item *item)
         {
             items.add(item);
         }
+        else
+        {
+            item->print();
+            delete item;
+        }
     }
 }
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -52,12 +52,12 @@ void StringTypedValue::printNoFlush()
 /**************************************
 **             INT VALUE             **
 **************************************/
-IntTypedValue::IntTypedValue(int64_t value)
+IntTypedValue::IntTypedValue(int_fast64_t value)
     : TypedValue(T_INT)
     , value(value)
 {}
 
-int64_t IntTypedValue::getValue()
+int_fast64_t IntTypedValue::getValue()
 {
     return value;
 }
@@ -203,12 +203,12 @@ void StringItem::printNoFlush()
 /**************************************
 **             INT ITEM              **
 **************************************/
-IntItem::IntItem(string key, int64_t value)
+IntItem::IntItem(string key, int_fast64_t value)
     : Item(key, T_INT)
     , value(value)
 {}
 
-int64_t IntItem::getValue()
+int_fast64_t IntItem::getValue()
 {
     return value;
 }

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -374,7 +374,7 @@ TypedValue **JSONArray::getValues()
     return values.getAsArray();
 }
 
-TypedValue *JSONArray::getValueAt(uint64_t index)
+TypedValue *JSONArray::getValueAt(uint_fast64_t index)
 {
     return values.get(index);
 }
@@ -400,7 +400,7 @@ void JSONArray::printValuesIndent(int indent, bool fromDict)
     }
     tabs[indent - 1] = '\0';
 
-    uint64_t size = getSize();
+    uint_fast64_t size = getSize();
     // Empty array
     if (size == 0)
     {
@@ -415,7 +415,7 @@ void JSONArray::printValuesIndent(int indent, bool fromDict)
 
     cout << (fromDict ? "" : tabs) << "[\n";
 
-    for (uint64_t i = 0; i < size; ++i)
+    for (uint_fast64_t i = 0; i < size; ++i)
     {
         TypedValue *value = values.get(i);
         if (value == nullptr)
@@ -507,10 +507,10 @@ Item **JSONDict::getItems()
 Item *JSONDict::getItem(string key)
 {
     const char *k_str = key.c_str();
-    uint64_t k_len = key.length();
+    uint_fast64_t k_len = key.length();
 
-    uint64_t size = getSize();
-    for (uint64_t i = 0; i < size; ++i)
+    uint_fast64_t size = getSize();
+    for (uint_fast64_t i = 0; i < size; ++i)
     {
         Item *it = items.get(i);
         if (it != nullptr)
@@ -546,7 +546,7 @@ void JSONDict::printItemsIndent(int indent, bool fromDict)
     }
     tabs[indent - 1] = '\0';
 
-    uint64_t size = getSize();
+    uint_fast64_t size = getSize();
     if (size == 0)
     {
         cout << (fromDict ? "" : tabs) << "{}";
@@ -560,7 +560,7 @@ void JSONDict::printItemsIndent(int indent, bool fromDict)
 
     cout << (fromDict ? "" : tabs) << "{\n";
 
-    for (uint64_t i = 0; i < size; ++i)
+    for (uint_fast64_t i = 0; i < size; ++i)
     {
         Item *it = items.get(i);
         if (it == nullptr)

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -488,7 +488,12 @@ void JSONDict::addItem(Item *item)
         }
         else
         {
-            item->print();
+#ifdef DEBUG
+            cout << "The item with key '" << item->getKey()
+                 << "' already exists, not adding it and freeing allocated "
+                    "memory"
+                 << endl;
+#endif
             delete item;
         }
     }

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -65,9 +65,9 @@ public:
     JSONArray();
     ~JSONArray();
 
-    uint64_t getSize();
+    uint_fast64_t getSize();
     TypedValue **getValues();
-    TypedValue *getValueAt(uint64_t index);
+    TypedValue *getValueAt(uint_fast64_t index);
 
     void addValue(TypedValue *value);
     void printValues();
@@ -89,7 +89,7 @@ public:
     JSONDict();
     ~JSONDict();
 
-    uint64_t getSize();
+    uint_fast64_t getSize();
     Item **getItems();
     Item *getItem(std::string key);
 
@@ -116,13 +116,13 @@ public:
 class IntTypedValue : public TypedValue
 {
 private:
-    int64_t value;
+    int_fast64_t value;
 
 public:
-    IntTypedValue(int64_t value);
+    IntTypedValue(int_fast64_t value);
 
     void printNoFlush();
-    int64_t getValue();
+    int_fast64_t getValue();
 };
 
 class DoubleTypedValue : public TypedValue

--- a/src/linked_lists.hpp
+++ b/src/linked_lists.hpp
@@ -106,7 +106,7 @@ public:
         }
     }
 
-    uint64_t getSize()
+    uint_fast64_t getSize()
     {
         return size;
     }

--- a/src/linked_lists.hpp
+++ b/src/linked_lists.hpp
@@ -18,7 +18,7 @@ public:
     T *elts[BASE_ARRAY_LEN] = { 0 };
     Link<T> *next = nullptr;
 
-    Link(){};
+    Link() {};
     ~Link()
     {
         for (unsigned char i = 0; i < BASE_ARRAY_LEN; ++i)
@@ -32,9 +32,9 @@ template <class T>
 class LinkedList
 {
 private:
-    uint64_t size = 0;
-    uint64_t insert_idx = 0;
-    uint64_t nb_deletion = 0;
+    uint_fast64_t size = 0;
+    uint_fast64_t insert_idx = 0;
+    uint_fast64_t nb_deletion = 0;
     Link<T> *head = nullptr;
     Link<T> *tail = nullptr;
 
@@ -94,7 +94,7 @@ private:
     }
 
 public:
-    LinkedList(){};
+    LinkedList() {};
     ~LinkedList()
     {
         Link<T> *tmp = head;
@@ -112,7 +112,7 @@ public:
     }
 
 #ifdef DEBUG
-    uint64_t getNbLinks()
+    uint_fast64_t getNbLinks()
     {
         if (head == nullptr)
         {
@@ -140,7 +140,7 @@ public:
     **                  the element of index 4 is '8'
     ** \returns The element at the given index if it exists, nullptr otherwise
     */
-    T *get(uint64_t index)
+    T *get(uint_fast64_t index)
     {
         if (head == nullptr || index >= size)
         {
@@ -148,7 +148,7 @@ public:
         }
 
         Link<T> *link = head;
-        uint64_t nb_encountered = 0;
+        uint_fast64_t nb_encountered = 0;
         while (link != nullptr)
         {
             for (unsigned char i = 0; i < BASE_ARRAY_LEN; ++i)
@@ -180,7 +180,7 @@ public:
             return nullptr;
         }
 
-        uint64_t local_insert_idx = 0;
+        uint_fast64_t local_insert_idx = 0;
         Link<T> *link = head;
         while (link != nullptr)
         {
@@ -220,7 +220,7 @@ public:
         ++size;
     }
 
-    void remove(uint64_t index)
+    void remove(uint_fast64_t index)
     {
         if (head == nullptr || index >= size)
         {
@@ -228,7 +228,7 @@ public:
         }
 
         Link<T> *link = head;
-        uint64_t nb_encountered = 0;
+        uint_fast64_t nb_encountered = 0;
         bool done = false;
         while (link != nullptr)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@ int main(int argc, char *argv[])
     JSON *j = parse(argv[1]);
     if (j == nullptr)
     {
+        printf("AAAAAAAAAAAAAAAAAA\n");
         return 1;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,6 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    printf("%s\n", argv[1]);
-
     JSON *j = parse(argv[1]);
     if (j == nullptr)
     {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -21,11 +21,12 @@ class StrAndLenTuple
 {
 public:
     char *str;
-    uint64_t len;
+    uint_fast64_t len;
     bool is_float;
     bool has_exponent;
 
-    StrAndLenTuple(char *str, uint64_t len, bool is_float, bool has_exponent)
+    StrAndLenTuple(char *str, uint_fast64_t len, bool is_float,
+                   bool has_exponent)
         : str(str)
         , len(len)
         , is_float(is_float)
@@ -51,38 +52,38 @@ public:
     ((l) == 0 || ((c) == 'f' && (l) != 5) || ((c) == 't' && (l) != 4))
 
 #ifndef READ_BUFF_MAX_SIZE_OVERRIDE
-#    define READ_BUFF_MAX_SIZE 1024
+#    define READ_BUFF_SIZE 1024
 #endif
 
 #ifndef MAX_NESTED_ARRAYS
-#    define MAX_NESTED_ARRAYS 255
+#    define MAX_NESTED_ARRAYS UINT_FAST8_MAX
 #endif
 
-#if MAX_NESTED_ARRAYS <= 255
-typedef uint8_t nested_arrays_t;
-#elif MAX_NESTED_ARRAYS <= 65536
-typedef uint16_t nested_arrays_t;
-#elif MAX_NESTED_ARRAYS <= 4294967296
-typedef uint32_t nested_arrays_t;
+#if MAX_NESTED_ARRAYS <= UINT_FAST8_MAX
+typedef uint_fast8_t nested_arrays_t;
+#elif MAX_NESTED_ARRAYS <= UINT_FAST16_MAX
+typedef uint_fast16_t nested_arrays_t;
+#elif MAX_NESTED_ARRAYS <= UINT_FAST32_MAX
+typedef uint_fast32_t nested_arrays_t;
 #else
-typedef uint64_t nested_arrays_t;
+typedef uint_fast64_t nested_arrays_t;
 #endif
 
-#if MAX_NESTED_DICTS <= 256
-typedef uint8_t nested_dicts_t;
-#elif MAX_NESTED_DICTS <= 65536
-typedef uint16_t nested_dicts_t;
-#elif MAX_NESTED_DICTS <= 4294967296
-typedef uint32_t nested_dicts_t;
+#if MAX_NESTED_DICTS <= UINT_FAST8_MAX
+typedef uint_fast8_t nested_dicts_t;
+#elif MAX_NESTED_DICTS <= UINT_FAST16_MAX
+typedef uint_fast16_t nested_dicts_t;
+#elif MAX_NESTED_DICTS <= UINT_FAST32_MAX
+typedef uint_fast32_t nested_dicts_t;
 #else
-typedef uint64_t nested_dicts_t;
+typedef uint_fast64_t nested_dicts_t;
 #endif
 
 /*******************************************************************************
 **                           FUNCTIONS DECLARATIONS                           **
 *******************************************************************************/
-JSONDict *parse_dict_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *pos);
-JSONDict *parse_dict(FILE *f, uint64_t *pos);
+JSONDict *parse_dict_buff(char b[READ_BUFF_SIZE], uint_fast64_t *pos);
+JSONDict *parse_dict(FILE *f, uint_fast64_t *pos);
 
 /*******************************************************************************
 **                              LOCAL FUNCTIONS                               **
@@ -90,11 +91,12 @@ JSONDict *parse_dict(FILE *f, uint64_t *pos);
 /**
 ** \brief Parses the string starting at 'pos + 1' (first char after the '"')
 ** \param buff The buffer containing the current json file or object
-** \param idx A pointer to the uint64_t containing the index of the '"' that
+** \param idx A pointer to the uint_fast64_t containing the index of the '"'
+*that
 **            started the string we want to parse
 ** \returns An empty string in case of error, the parsed string otherwise
 */
-string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
+string parse_string_buff(char buff[READ_BUFF_SIZE], uint_fast64_t *idx)
 {
     if (idx == nullptr)
     {
@@ -102,11 +104,11 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Counts the number of characters until the first one that is an 'end char'
-    uint64_t end_idx = *idx + 1;
-    uint64_t initial_i = end_idx;
+    uint_fast64_t end_idx = *idx + 1;
+    uint_fast64_t initial_i = end_idx;
     char c = 0;
     char prev_c = 0;
-    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
+    for (; end_idx < READ_BUFF_SIZE; ++end_idx)
     {
         c = buff[end_idx];
         if (IS_STRING_END(c))
@@ -117,7 +119,7 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Number of chars
-    uint64_t len = end_idx - initial_i;
+    uint_fast64_t len = end_idx - initial_i;
     if (len == 0)
     {
         return string();
@@ -129,7 +131,7 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
         return string();
     }
 
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         str[i] = buff[i + initial_i];
     }
@@ -144,11 +146,12 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
 /**
 ** \brief Parses the string starting at 'pos + 1' (first char after the '"')
 ** \param f The file stream
-** \param pos A pointer to the uint64_t containing the position of the '"' that
+** \param pos A pointer to the uint_fast64_t containing the position of the '"'
+*that
 **            started the string we want to parse
 ** \returns An empty string in case of error, the parsed string otherwise
 */
-string parse_string(FILE *f, uint64_t *pos)
+string parse_string(FILE *f, uint_fast64_t *pos)
 {
     if (f == nullptr || pos == nullptr)
     {
@@ -156,7 +159,7 @@ string parse_string(FILE *f, uint64_t *pos)
     }
 
     // TODO: Test if + 1 is needed
-    uint64_t end_pos = *pos;
+    uint_fast64_t end_pos = *pos;
     char c = 0;
     char prev_c = 0;
     while ((c = fgetc(f)) != EOF)
@@ -172,7 +175,7 @@ string parse_string(FILE *f, uint64_t *pos)
         prev_c = c;
     }
 
-    uint64_t len = end_pos - *pos - 1;
+    uint_fast64_t len = end_pos - *pos - 1;
     if (len == 0)
     {
         return string();
@@ -206,20 +209,20 @@ string parse_string(FILE *f, uint64_t *pos)
 ** \returns The 0 in case of error (or if the number was 0), the number
 **          otherwise
 */
-int64_t str_to_long(StrAndLenTuple *sl)
+int_fast64_t str_to_long(StrAndLenTuple *sl)
 {
     char *str = sl->str;
-    uint64_t len = sl->len;
+    uint_fast64_t len = sl->len;
     if (str == nullptr || len == 0)
     {
         return 0;
     }
 
-    int64_t res = 0;
-    uint64_t exponent = 0;
+    int_fast64_t res = 0;
+    uint_fast64_t exponent = 0;
     char is_negative = str[0] == '-' ? -1 : 1;
     char is_in_exponent = 0;
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         if (sl->has_exponent && (str[i] == 'e' || str[i] == 'E'))
         {
@@ -253,7 +256,7 @@ int64_t str_to_long(StrAndLenTuple *sl)
 double str_to_double(StrAndLenTuple *sl)
 {
     char *str = sl->str;
-    uint64_t len = sl->len;
+    uint_fast64_t len = sl->len;
     if (str == nullptr || len == 0)
     {
         return 0;
@@ -261,14 +264,14 @@ double str_to_double(StrAndLenTuple *sl)
 
     double res = 0; // Integer part
     double dot_res = 0; // Decimal part
-    uint64_t exponent = 0; // Only used if sl->has_exponent() is true
-    uint64_t nb_digits_dot = 1;
+    uint_fast64_t exponent = 0; // Only used if sl->has_exponent() is true
+    uint_fast64_t nb_digits_dot = 1;
     // If the number is negative, this is set to -1 and the final res is
     // multiplied by it
     char is_negative = str[0] == '-' ? -1 : 1;
     char dot_reached = 0;
     char is_in_exponent = 0;
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         if (str[i] == '.')
         {
@@ -300,14 +303,14 @@ double str_to_double(StrAndLenTuple *sl)
         : is_negative * (res + (dot_res / nb_digits_dot));
 }
 
-bool is_float(char *str, uint64_t len)
+bool is_float(char *str, uint_fast64_t len)
 {
     if (str == nullptr)
     {
         return false;
     }
 
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         if (str[i] == '.')
         {
@@ -317,14 +320,14 @@ bool is_float(char *str, uint64_t len)
     return false;
 }
 
-bool has_exponent(char *str, uint64_t len)
+bool has_exponent(char *str, uint_fast64_t len)
 {
     if (str == nullptr)
     {
         return false;
     }
 
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         if (str[i] == 'e' || str[i] == 'E')
         {
@@ -343,7 +346,7 @@ bool has_exponent(char *str, uint64_t len)
 **          char array, the length of the char array and whether the number is a
 **          float and has an exponent
 */
-StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
+StrAndLenTuple parse_number_buff(char buff[READ_BUFF_SIZE], uint_fast64_t *idx)
 {
     if (idx == nullptr)
     {
@@ -351,10 +354,10 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Counts the number of characters until the first one that is an 'end char'
-    uint64_t end_idx = *idx;
-    uint64_t initial_i = end_idx;
+    uint_fast64_t end_idx = *idx;
+    uint_fast64_t initial_i = end_idx;
     char c = 0;
-    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
+    for (; end_idx < READ_BUFF_SIZE; ++end_idx)
     {
         c = buff[end_idx];
         if (IS_END_CHAR(c))
@@ -364,7 +367,7 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Number of chars
-    uint64_t len = end_idx - initial_i;
+    uint_fast64_t len = end_idx - initial_i;
     if (len == 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
@@ -377,7 +380,7 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
         return StrAndLenTuple(nullptr, 0, false, false);
     }
 
-    for (uint64_t i = 0; i < len; ++i)
+    for (uint_fast64_t i = 0; i < len; ++i)
     {
         str[i] = buff[i + initial_i];
     }
@@ -395,7 +398,7 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
 ** \param pos The pos of the start of the number of which we are currently
 **            acquiring the length
 */
-StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
+StrAndLenTuple parse_number(FILE *f, uint_fast64_t *pos)
 {
     if (f == nullptr || pos == nullptr)
     {
@@ -406,7 +409,7 @@ StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
     --(*pos);
 
     // Obtains the length of the value
-    uint64_t end_pos = *pos;
+    uint_fast64_t end_pos = *pos;
     if (fseek(f, end_pos++, SEEK_SET) != 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
@@ -425,7 +428,7 @@ StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
         }
     }
 
-    uint64_t len = end_pos - (*pos) - 1;
+    uint_fast64_t len = end_pos - (*pos) - 1;
     if (len == 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
@@ -447,16 +450,16 @@ StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
 /**
 ** \returns 5 if false, 4 if true, 0 otherwise
 **/
-uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
+uint_fast64_t parse_boolean_buff(char buff[READ_BUFF_SIZE], uint_fast64_t *idx)
 {
     if (idx == nullptr)
     {
         return 0;
     }
 
-    uint64_t end_idx = *idx;
+    uint_fast64_t end_idx = *idx;
     char c = 0;
-    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
+    for (; end_idx < READ_BUFF_SIZE; ++end_idx)
     {
         c = buff[end_idx];
         if (IS_END_CHAR(c))
@@ -464,7 +467,7 @@ uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
             break;
         }
     }
-    uint64_t len = end_idx - *idx;
+    uint_fast64_t len = end_idx - *idx;
     (*idx) += len - 1;
     return len;
 }
@@ -472,7 +475,7 @@ uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
 /**
 ** \returns 5 if false, 4 if true, 0 otherwise
 **/
-uint64_t parse_boolean(FILE *f, uint64_t *pos)
+uint_fast64_t parse_boolean(FILE *f, uint_fast64_t *pos)
 {
     if (f == nullptr || pos == nullptr)
     {
@@ -482,7 +485,7 @@ uint64_t parse_boolean(FILE *f, uint64_t *pos)
     // Because we already read the first character
     --(*pos);
 
-    uint64_t end_pos = (*pos);
+    uint_fast64_t end_pos = (*pos);
     if (fseek(f, end_pos++, SEEK_SET) != 0)
     {
         return 0;
@@ -500,7 +503,7 @@ uint64_t parse_boolean(FILE *f, uint64_t *pos)
             break;
         }
     }
-    uint64_t len = end_pos - (*pos) - 1;
+    uint_fast64_t len = end_pos - (*pos) - 1;
     (*pos) += len;
     return len;
 }
@@ -511,7 +514,7 @@ uint64_t parse_boolean(FILE *f, uint64_t *pos)
 **            current array
 ** \returns The total number of characters in the current array
 */
-uint64_t get_nb_chars_in_array(FILE *f, uint64_t pos)
+uint_fast64_t get_nb_chars_in_array(FILE *f, uint_fast64_t pos)
 {
     if (f == nullptr)
     {
@@ -523,7 +526,7 @@ uint64_t get_nb_chars_in_array(FILE *f, uint64_t pos)
         return 0;
     }
 
-    uint64_t nb_chars = 0;
+    uint_fast64_t nb_chars = 0;
     char c = 0;
     nested_arrays_t is_in_array = 1;
     nested_dicts_t is_in_dict = 0;
@@ -581,14 +584,15 @@ uint64_t get_nb_chars_in_array(FILE *f, uint64_t pos)
 **            current array
 ** \returns The number of elements of the current array
 */
-uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
+uint_fast64_t get_nb_elts_array_buff(char buff[READ_BUFF_SIZE],
+                                     uint_fast64_t idx)
 {
     if (buff[idx] == ']')
     {
         return 0;
     }
 
-    uint64_t nb_elts = 0;
+    uint_fast64_t nb_elts = 0;
     char c = 0;
     char prev_c = 0;
     nested_arrays_t is_in_array = 1;
@@ -596,7 +600,7 @@ uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
     char is_in_string = 0;
     char is_backslashing = 0;
     char comma_encountered = 0;
-    while (idx < READ_BUFF_MAX_SIZE)
+    while (idx < READ_BUFF_SIZE)
     {
         if (!is_in_array)
         {
@@ -665,20 +669,20 @@ uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
 **            begins the current array
 ** \returns The number of elements of the current array
 */
-uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
+uint_fast64_t get_nb_elts_array(FILE *f, uint_fast64_t pos)
 {
     if (f == nullptr)
     {
         return 0;
     }
 
-    uint64_t offset = pos;
+    uint_fast64_t offset = pos;
     if (fseek(f, offset++, SEEK_SET) != 0)
     {
         return 0;
     }
 
-    uint64_t nb_elts = 0;
+    uint_fast64_t nb_elts = 0;
 
     char c = 0;
     char prev_c = 0;
@@ -766,7 +770,7 @@ uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
 **            current dict
 ** \returns The total number of characters in the current dict
 */
-uint64_t get_nb_chars_in_dict(FILE *f, uint64_t pos)
+uint_fast64_t get_nb_chars_in_dict(FILE *f, uint_fast64_t pos)
 {
     // We already read the first char but the pos was not incremented yet
     //++pos;
@@ -775,7 +779,7 @@ uint64_t get_nb_chars_in_dict(FILE *f, uint64_t pos)
         return 0;
     }
 
-    uint64_t nb_chars = 0;
+    uint_fast64_t nb_chars = 0;
     char c = 0;
     nested_dicts_t is_in_dict = 1;
     nested_arrays_t is_in_array = 0;
@@ -833,24 +837,25 @@ uint64_t get_nb_chars_in_dict(FILE *f, uint64_t pos)
 **            current dict
 ** \returns The number of elements of the current dict
 */
-uint64_t get_nb_elts_dict_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
+uint_fast64_t get_nb_elts_dict_buff(char buff[READ_BUFF_SIZE],
+                                    uint_fast64_t idx)
 {
-    if (idx >= READ_BUFF_MAX_SIZE || buff[idx] == '}')
+    if (idx >= READ_BUFF_SIZE || buff[idx] == '}')
     {
         return 0;
     }
 
-    uint64_t nb_elts = 0;
+    uint_fast64_t nb_elts = 0;
     // Used for the case where the dict contains only one element, and so does
     // not contain a ','
-    uint64_t single_elt_found = 0;
+    uint_fast64_t single_elt_found = 0;
 
     char c = 0;
     nested_dicts_t is_in_dict = 1;
     nested_arrays_t is_in_array = 0;
     char is_in_string = 0;
     char is_backslashing = 0;
-    while (idx < READ_BUFF_MAX_SIZE)
+    while (idx < READ_BUFF_SIZE)
     {
         c = buff[idx];
         if (!is_in_dict || c == 0)
@@ -903,23 +908,23 @@ uint64_t get_nb_elts_dict_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
 **            begins the current dict
 ** \returns The number of elements of the current dict
 */
-uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
+uint_fast64_t get_nb_elts_dict(FILE *f, uint_fast64_t pos)
 {
     if (f == nullptr)
     {
         return 0;
     }
 
-    uint64_t offset = pos;
+    uint_fast64_t offset = pos;
     if (fseek(f, offset++, SEEK_SET) != 0)
     {
         return 0;
     }
 
-    uint64_t nb_elts = 0;
+    uint_fast64_t nb_elts = 0;
     // Used for the case where the dict contains only one element, and so does
     // not contain a ','
-    uint64_t single_elt_found = 0;
+    uint_fast64_t single_elt_found = 0;
 
     char c = 0;
     nested_dicts_t is_in_dict = 1;
@@ -981,14 +986,14 @@ uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
 ** \param idx The index of the character '[' that begins the current array
 ** \returns The json array parsed from the position
 */
-JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
+JSONArray *parse_array_buff(char b[READ_BUFF_SIZE], uint_fast64_t *idx)
 {
-    uint64_t i = idx == nullptr ? 1 : (*idx) + 1;
+    uint_fast64_t i = idx == nullptr ? 1 : (*idx) + 1;
 
     JSONArray *ja = new JSONArray();
 
-    uint64_t nb_elts_parsed = 0;
-    uint64_t nb_elts = get_nb_elts_array_buff(b, i);
+    uint_fast64_t nb_elts_parsed = 0;
+    uint_fast64_t nb_elts = get_nb_elts_array_buff(b, i);
     if (nb_elts == 0)
     {
         return ja;
@@ -997,8 +1002,8 @@ JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
     char c = 0;
     // We start at 1 because if we entered this function, it means that we
     // already read a '['
-    uint64_t initial_i = i;
-    for (; i < READ_BUFF_MAX_SIZE; ++i)
+    uint_fast64_t initial_i = i;
+    for (; i < READ_BUFF_SIZE; ++i)
     {
         c = b[i];
         if (c == 0 || nb_elts_parsed >= nb_elts)
@@ -1031,7 +1036,7 @@ JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
         }
         else if (IS_BOOL_START(c))
         {
-            uint64_t len = parse_boolean_buff(b, &i);
+            uint_fast64_t len = parse_boolean_buff(b, &i);
             if (IS_NOT_BOOLEAN(c, len))
             {
                 continue;
@@ -1069,7 +1074,7 @@ JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
 **            begins the current array
 ** \returns The json array parsed from the position
 */
-JSONArray *parse_array(FILE *f, uint64_t *pos)
+JSONArray *parse_array(FILE *f, uint_fast64_t *pos)
 {
     if (f == nullptr || pos == nullptr)
     {
@@ -1078,8 +1083,8 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
 
     JSONArray *ja = new JSONArray();
 
-    uint64_t nb_elts_parsed = 0;
-    uint64_t nb_elts = get_nb_elts_array(f, *pos);
+    uint_fast64_t nb_elts_parsed = 0;
+    uint_fast64_t nb_elts = get_nb_elts_array(f, *pos);
     if (nb_elts == 0)
     {
         return ja;
@@ -1128,7 +1133,7 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
         }
         else if (IS_BOOL_START(c))
         {
-            uint64_t len = parse_boolean(f, pos);
+            uint_fast64_t len = parse_boolean(f, pos);
             if (len == 0 || (c == 'f' && len != 5) || (c == 't' && len != 4))
             {
                 continue;
@@ -1144,11 +1149,11 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
         }
         else if (c == '[')
         {
-            uint64_t nb_chars = get_nb_chars_in_array(f, *pos);
+            uint_fast64_t nb_chars = get_nb_chars_in_array(f, *pos);
             JSONArray *ja = nullptr;
-            if (nb_chars <= READ_BUFF_MAX_SIZE)
+            if (nb_chars <= READ_BUFF_SIZE)
             {
-                char b[READ_BUFF_MAX_SIZE] = {};
+                char b[READ_BUFF_SIZE] = {};
                 fread(b, sizeof(char), nb_chars, f);
                 ja = parse_array_buff(b, nullptr);
             }
@@ -1161,11 +1166,11 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
         }
         else if (c == '{')
         {
-            uint64_t nb_chars = get_nb_chars_in_dict(f, *pos);
+            uint_fast64_t nb_chars = get_nb_chars_in_dict(f, *pos);
             JSONDict *jd = nullptr;
-            if (nb_chars <= READ_BUFF_MAX_SIZE)
+            if (nb_chars <= READ_BUFF_SIZE)
             {
-                char b[READ_BUFF_MAX_SIZE] = {};
+                char b[READ_BUFF_SIZE] = {};
                 // pos - 1 because we re-read the '{'
                 if (fseek(f, *pos - 1, SEEK_SET) != 0)
                 {
@@ -1201,15 +1206,15 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
 **            index starts at 0
 ** \returns The json dict parsed from the index
 */
-JSONDict *parse_dict_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
+JSONDict *parse_dict_buff(char b[READ_BUFF_SIZE], uint_fast64_t *idx)
 {
-    uint64_t i = idx == nullptr ? 1 : (*idx) + 1;
+    uint_fast64_t i = idx == nullptr ? 1 : (*idx) + 1;
 
     JSONDict *jd = new JSONDict();
 
     string key = string();
-    uint64_t nb_elts_parsed = 0;
-    uint64_t nb_elts = get_nb_elts_dict_buff(b, i);
+    uint_fast64_t nb_elts_parsed = 0;
+    uint_fast64_t nb_elts = get_nb_elts_dict_buff(b, i);
     if (nb_elts == 0)
     {
         return jd;
@@ -1219,8 +1224,8 @@ JSONDict *parse_dict_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
     char is_waiting_key = 1;
     // We start at 1 because if we entered this function, it means that we
     // already read a '{'
-    uint64_t initial_i = i;
-    for (; i < READ_BUFF_MAX_SIZE; ++i)
+    uint_fast64_t initial_i = i;
+    for (; i < READ_BUFF_SIZE; ++i)
     {
         c = b[i];
         if (c == 0 || nb_elts_parsed >= nb_elts)
@@ -1261,7 +1266,7 @@ JSONDict *parse_dict_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
         }
         else if (IS_BOOL_START(c))
         {
-            uint64_t len = parse_boolean_buff(b, &i);
+            uint_fast64_t len = parse_boolean_buff(b, &i);
             if (IS_NOT_BOOLEAN(c, len))
             {
                 continue;
@@ -1303,7 +1308,7 @@ JSONDict *parse_dict_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
 **            the '{' that begins the current dict
 ** \returns The json dict parsed from the position
 */
-JSONDict *parse_dict(FILE *f, uint64_t *pos)
+JSONDict *parse_dict(FILE *f, uint_fast64_t *pos)
 {
     if (f == nullptr || pos == nullptr)
     {
@@ -1311,7 +1316,7 @@ JSONDict *parse_dict(FILE *f, uint64_t *pos)
     }
 
     JSONDict *jd = new JSONDict();
-    // uint64_t i = *pos;
+    // uint_fast64_t i = *pos;
 
     if (fseek(f, *pos, SEEK_SET) != 0)
     {
@@ -1319,8 +1324,8 @@ JSONDict *parse_dict(FILE *f, uint64_t *pos)
     }
 
     string key = string();
-    uint64_t nb_elts_parsed = 0;
-    uint64_t nb_elts = get_nb_elts_dict(f, *pos);
+    uint_fast64_t nb_elts_parsed = 0;
+    uint_fast64_t nb_elts = get_nb_elts_dict(f, *pos);
 
     char c = 0;
     char is_waiting_key = 1;
@@ -1359,7 +1364,7 @@ JSONDict *parse_dict(FILE *f, uint64_t *pos)
         }
         else if (IS_BOOL_START(c))
         {
-            uint64_t len = parse_boolean(f, pos);
+            uint_fast64_t len = parse_boolean(f, pos);
             if (len == 0 || (c == 'f' && len != 5) || (c == 't' && len != 4))
             {
                 continue;
@@ -1408,7 +1413,7 @@ JSON *parse(char *file)
         return nullptr;
     }
 
-    uint64_t offset = 0;
+    uint_fast64_t offset = 0;
     if (fseek(f, offset++, SEEK_SET) != 0)
     {
         fclose(f);
@@ -1419,10 +1424,10 @@ JSON *parse(char *file)
     if (c == '{')
     {
         JSONDict *jd = nullptr;
-        uint64_t nb_chars = get_nb_chars_in_dict(f, offset);
-        if (nb_chars <= READ_BUFF_MAX_SIZE)
+        uint_fast64_t nb_chars = get_nb_chars_in_dict(f, offset);
+        if (nb_chars <= READ_BUFF_SIZE)
         {
-            char b[READ_BUFF_MAX_SIZE] = {};
+            char b[READ_BUFF_SIZE] = {};
             if (fseek(f, offset, SEEK_SET) != 0)
             {
                 fclose(f);
@@ -1442,10 +1447,10 @@ JSON *parse(char *file)
     else if (c == '[')
     {
         JSONArray *ja = nullptr;
-        uint64_t nb_chars = get_nb_chars_in_array(f, offset);
-        if (nb_chars <= READ_BUFF_MAX_SIZE)
+        uint_fast64_t nb_chars = get_nb_chars_in_array(f, offset);
+        if (nb_chars <= READ_BUFF_SIZE)
         {
-            char b[READ_BUFF_MAX_SIZE] = {};
+            char b[READ_BUFF_SIZE] = {};
             if (fseek(f, offset, SEEK_SET) != 0)
             {
                 fclose(f);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -103,13 +103,13 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Counts the number of characters until the first one that is an 'end char'
-    uint64_t tmp_idx = *idx + 1;
-    uint64_t initial_i = tmp_idx;
+    uint64_t end_idx = *idx + 1;
+    uint64_t initial_i = end_idx;
     char c = 0;
     char prev_c = 0;
-    for (; tmp_idx < READ_BUFF_MAX_SIZE; ++tmp_idx)
+    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
     {
-        c = buff[tmp_idx];
+        c = buff[end_idx];
         if (IS_STRING_END(c))
         {
             break;
@@ -118,7 +118,7 @@ string parse_string_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
     }
 
     // Number of chars
-    uint64_t len = tmp_idx - initial_i;
+    uint64_t len = end_idx - initial_i;
     if (len == 0)
     {
         return string();
@@ -157,7 +157,7 @@ string parse_string(FILE *f, uint64_t *pos)
     }
 
     // TODO: Test if + 1 is needed
-    uint64_t i = *pos;
+    uint64_t end_pos = *pos;
     char c = 0;
     char prev_c = 0;
     while ((c = fgetc(f)) != EOF)
@@ -166,14 +166,14 @@ string parse_string(FILE *f, uint64_t *pos)
         {
             break;
         }
-        if (fseek(f, i++, SEEK_SET) != 0)
+        if (fseek(f, end_pos++, SEEK_SET) != 0)
         {
             break;
         }
         prev_c = c;
     }
 
-    uint64_t len = i - *pos - 1;
+    uint64_t len = end_pos - *pos - 1;
     if (len == 0)
     {
         return string();
@@ -338,26 +338,26 @@ bool has_exponent(char *str, uint64_t len)
 /**
 ** \brief Reads the buffer from the given pos - 1
 ** \param buff The buffer containing the current json file or object
-** \param pos The position of the second character of the number (the first one
+** \param idx The index of the second character of the number (the first one
 **            was already read)
 ** \returns An instance of the StrAndLenTuple class containing the number as a
 **          char array, the length of the char array and whether the number is a
 **          float and has an exponent
 */
-StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *pos)
+StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
 {
-    if (pos == nullptr)
+    if (idx == nullptr)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
     }
 
     // Counts the number of characters until the first one that is an 'end char'
-    uint64_t idx = *pos;
-    uint64_t initial_i = idx;
+    uint64_t end_idx = *idx;
+    uint64_t initial_i = end_idx;
     char c = 0;
-    for (; idx < READ_BUFF_MAX_SIZE; ++idx)
+    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
     {
-        c = buff[idx];
+        c = buff[end_idx];
         if (IS_END_CHAR(c))
         {
             break;
@@ -365,7 +365,7 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *pos)
     }
 
     // Number of chars
-    uint64_t len = idx - initial_i;
+    uint64_t len = end_idx - initial_i;
     if (len == 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
@@ -383,7 +383,7 @@ StrAndLenTuple parse_number_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *pos)
         str[i] = buff[i + initial_i];
     }
 
-    (*pos) += len - 1;
+    (*idx) += len - 1;
     return StrAndLenTuple(str, len, is_float(str, len), has_exponent(str, len));
 }
 
@@ -407,26 +407,26 @@ StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
     --(*pos);
 
     // Obtains the length of the value
-    uint64_t size = *pos;
-    if (fseek(f, size++, SEEK_SET) != 0)
+    uint64_t end_pos = *pos;
+    if (fseek(f, end_pos++, SEEK_SET) != 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
     }
 
-    char c = '\0';
+    char c = 0;
     while ((c = fgetc(f)) != EOF)
     {
         if (IS_END_CHAR(c))
         {
             break;
         }
-        if (fseek(f, size++, SEEK_SET) != 0)
+        if (fseek(f, end_pos++, SEEK_SET) != 0)
         {
             break;
         }
     }
 
-    uint64_t len = size - (*pos) - 1;
+    uint64_t len = end_pos - (*pos) - 1;
     if (len == 0)
     {
         return StrAndLenTuple(nullptr, 0, false, false);
@@ -448,25 +448,25 @@ StrAndLenTuple parse_number(FILE *f, uint64_t *pos)
 /**
 ** \returns 5 if false, 4 if true, 0 otherwise
 **/
-uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *pos)
+uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *idx)
 {
-    if (pos == nullptr)
+    if (idx == nullptr)
     {
         return 0;
     }
 
-    uint64_t idx = *pos;
+    uint64_t end_idx = *idx;
     char c = 0;
-    for (; idx < READ_BUFF_MAX_SIZE; ++idx)
+    for (; end_idx < READ_BUFF_MAX_SIZE; ++end_idx)
     {
-        c = buff[idx];
+        c = buff[end_idx];
         if (IS_END_CHAR(c))
         {
             break;
         }
     }
-    uint64_t len = idx - *pos;
-    (*pos) += len - 1;
+    uint64_t len = end_idx - *idx;
+    (*idx) += len - 1;
     return len;
 }
 
@@ -483,8 +483,8 @@ uint64_t parse_boolean(FILE *f, uint64_t *pos)
     // Because we already read the first character
     --(*pos);
 
-    uint64_t size = (*pos);
-    if (fseek(f, size++, SEEK_SET) != 0)
+    uint64_t end_pos = (*pos);
+    if (fseek(f, end_pos++, SEEK_SET) != 0)
     {
         return 0;
     }
@@ -496,12 +496,12 @@ uint64_t parse_boolean(FILE *f, uint64_t *pos)
         {
             break;
         }
-        if (fseek(f, size++, SEEK_SET) != 0)
+        if (fseek(f, end_pos++, SEEK_SET) != 0)
         {
             break;
         }
     }
-    uint64_t len = size - (*pos) - 1;
+    uint64_t len = end_pos - (*pos) - 1;
     (*pos) += len;
     return len;
 }
@@ -590,7 +590,7 @@ uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
         return 0;
     }
 
-    uint64_t size = 0;
+    uint64_t nb_elts = 0;
     char c = 0;
     char prev_c = 0;
     nested_arrays_t is_in_array = 1;
@@ -640,7 +640,7 @@ uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
             }
             else if (!is_in_dict && is_in_array == 1 && c == ',')
             {
-                ++size;
+                ++nb_elts;
             }
         }
         ++idx;
@@ -654,11 +654,11 @@ uint64_t get_nb_elts_array_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t idx)
     // If there was only one value, there was no ',', so the element wasn't
     // detected or if at least one element was found, it means that a ',' was
     // found
-    if ((size == 0 && prev_c != 0) || (size >= 1 && comma_encountered))
+    if ((nb_elts == 0 && prev_c != 0) || (nb_elts >= 1 && comma_encountered))
     {
-        ++size;
+        ++nb_elts;
     }
-    return size;
+    return nb_elts;
 }
 
 /**
@@ -680,7 +680,7 @@ uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
         return 0;
     }
 
-    uint64_t size = 0;
+    uint64_t nb_elts = 0;
 
     char c = 0;
     char prev_c = 0;
@@ -737,7 +737,7 @@ uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
             }
             else if (!is_in_dict && is_in_array == 1 && c == ',')
             {
-                ++size;
+                ++nb_elts;
             }
         }
 
@@ -755,11 +755,11 @@ uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
     // If there was only one value, there was no ',', so the element wasn't
     // detected or if at least one element was found, it means that a ',' was
     // found
-    if ((size == 0 && prev_c != 0) || (size >= 1 && comma_encountered))
+    if ((nb_elts == 0 && prev_c != 0) || (nb_elts >= 1 && comma_encountered))
     {
-        ++size;
+        ++nb_elts;
     }
-    return size;
+    return nb_elts;
 }
 
 /**
@@ -846,7 +846,7 @@ uint64_t get_nb_elts_dict_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t pos)
         return 0;
     }
 
-    uint64_t size = 0;
+    uint64_t nb_elts = 0;
     // Used for the case where the dict contains only one element, and so does
     // not contain a ','
     uint64_t single_elt_found = 0;
@@ -895,12 +895,12 @@ uint64_t get_nb_elts_dict_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t pos)
             }
             else if (!is_in_array && is_in_dict == 1 && c == ',')
             {
-                ++size;
+                ++nb_elts;
             }
         }
         ++pos;
     }
-    return size == 0 ? single_elt_found : size + 1;
+    return nb_elts == 0 ? single_elt_found : nb_elts + 1;
 }
 
 /**
@@ -922,12 +922,12 @@ uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
         return 0;
     }
 
-    uint64_t size = 0;
+    uint64_t nb_elts = 0;
     // Used for the case where the dict contains only one element, and so does
     // not contain a ','
     uint64_t single_elt_found = 0;
 
-    char c = '\0';
+    char c = 0;
     nested_dicts_t is_in_dict = 1;
     nested_arrays_t is_in_array = 0;
     char is_in_string = 0;
@@ -970,7 +970,7 @@ uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
             }
             else if (!is_in_array && is_in_dict == 1 && c == ',')
             {
-                ++size;
+                ++nb_elts;
             }
         }
 
@@ -979,7 +979,7 @@ uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
             break;
         }
     }
-    return size == 0 ? single_elt_found : size + 1;
+    return nb_elts == 0 ? single_elt_found : nb_elts + 1;
 }
 
 /**

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -979,17 +979,14 @@ uint64_t get_nb_elts_dict(FILE *f, uint64_t pos)
 ** \param idx The index of the character '[' that begins the current array
 ** \returns The json array parsed from the position
 */
-JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *pos)
+JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *idx)
 {
-    if (pos == nullptr)
-    {
-        return nullptr;
-    }
+    uint64_t i = idx == nullptr ? 1 : (*idx) + 1;
 
     JSONArray *ja = new JSONArray();
 
     uint64_t nb_elts_parsed = 0;
-    uint64_t nb_elts = get_nb_elts_array_buff(b, *pos + 1);
+    uint64_t nb_elts = get_nb_elts_array_buff(b, i);
     if (nb_elts == 0)
     {
         return ja;
@@ -998,7 +995,6 @@ JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *pos)
     char c = 0;
     // We start at 1 because if we entered this function, it means that we
     // already read a '['
-    uint64_t i = *pos + 1;
     uint64_t initial_i = i;
     for (; i < READ_BUFF_MAX_SIZE; ++i)
     {
@@ -1058,7 +1054,10 @@ JSONArray *parse_array_buff(char b[READ_BUFF_MAX_SIZE], uint64_t *pos)
             ++nb_elts_parsed;
         }
     }
-    (*pos) += i - initial_i;
+    if (idx != nullptr)
+    {
+        (*idx) += i - initial_i;
+    }
     return ja;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -440,7 +440,7 @@ uint64_t parse_boolean_buff(char buff[READ_BUFF_MAX_SIZE], uint64_t *pos)
         }
     }
     uint64_t len = idx - *pos;
-    (*pos) += len;
+    (*pos) += len - 1;
     return len;
 }
 
@@ -900,6 +900,7 @@ JSONDict *parse_json_dict(FILE *f, uint64_t *pos)
     JSONDict *jd = new JSONDict();
 
     uint64_t nb_chars_in_dict = get_nb_chars_in_dict(f, *pos);
+    printf("nb chars = %lu\n", nb_chars_in_dict);
 
     if (fseek(f, *pos, SEEK_SET) != 0)
     {
@@ -984,7 +985,8 @@ JSONDict *parse_json_dict(FILE *f, uint64_t *pos)
             }
             else if (c == '{')
             {
-                jd->addItem(new DictItem(key, parse_json_dict(f, pos)));
+                ++i;
+                jd->addItem(new DictItem(key, parse_json_dict(f, &i)));
                 ++nb_elts_parsed;
             }
             else if (c == ',')

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -46,6 +46,10 @@ public:
 
 #define IS_END_CHAR(c) ((c) == ',' || (c) == '\n' || (c) == ']' || (c) == '}')
 
+#ifndef READ_BUFF_MAX_SIZE_OVERRIDE
+#    define READ_BUFF_MAX_SIZE 1024
+#endif
+
 /*******************************************************************************
 **                           FUNCTIONS DECLARATIONS                           **
 *******************************************************************************/

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -768,6 +768,8 @@ uint64_t get_nb_elts_array(FILE *f, uint64_t pos)
 */
 uint64_t get_nb_chars_in_dict(FILE *f, uint64_t pos)
 {
+    // We already read the first char but the pos was not incremented yet
+    ++pos;
     if (f == nullptr || fseek(f, pos++, SEEK_SET) != 0)
     {
         return 0;
@@ -1085,7 +1087,7 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
     }
 
     // Sets the reading position back to the first character after the '['
-    if (fseek(f, (*pos)++, SEEK_SET) != 0)
+    if (fseek(f, (*pos), SEEK_SET) != 0)
     {
         return nullptr;
     }
@@ -1093,7 +1095,6 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
     char c = 0;
     // We start at 1 because if we entered this function, it means that we
     // already read a '['
-    // while ((c = fgetc(f)) != EOF)
     for (; nb_elts_parsed <= nb_elts; ++(*pos))
     {
         c = fgetc(f);
@@ -1161,7 +1162,7 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
         }
         else if (c == '{')
         {
-            uint64_t nb_chars = get_nb_chars_in_dict(f, *pos - 1);
+            uint64_t nb_chars = get_nb_chars_in_dict(f, *pos);
             printf("nb chars pre dict = %lu\n", nb_chars);
             JSONDict *jd = nullptr;
             if (nb_chars <= READ_BUFF_MAX_SIZE)
@@ -1170,6 +1171,7 @@ JSONArray *parse_array(FILE *f, uint64_t *pos)
                 char b[READ_BUFF_MAX_SIZE] = {};
                 fread(b, sizeof(char), nb_chars, f);
                 jd = parse_dict_buff(b, nullptr);
+                (*pos) += nb_chars;
             }
             else
             {

--- a/t.json
+++ b/t.json
@@ -1,4 +1,22 @@
 {
-  "test": [[]]
+  "test": "stringi[nining",
+  "num": 51065.689888564,
+  "boool": true,
+  "empty": {
+    "t": {
+      "t": {
+        "t": {
+          "t": {}
+        }
+      }
+    }
+  },
+  "dict": {
+    "empty": [[1, [[2], [[]], 3]]],
+    "num": 563,
+    "u": 2e10
+  },
+  "boo": false,
+  "n": null,
+  "arr": ["testing", 546884, null, false, [1], [1, 2, 3, 5], true]
 }
-


### PR DESCRIPTION
The idea is to define a fix number that will be the max size of the buffer, and we will use `fread()` to fill it in one go instead of using `fseek()` and `fgetc()`.

When the number of characters in the object we want to parse is bigger that the number we defined, we will use the `fseek()` and `fgetc()` method.